### PR TITLE
Fix connecting to a console WAAPI session taking additional 15 seconds

### DIFF
--- a/WwiseTools/Src/Utils/WwiseUtility.cs
+++ b/WwiseTools/Src/Utils/WwiseUtility.cs
@@ -183,14 +183,21 @@ namespace WwiseTools.Utils
                 for (int i = 1; i <= retryCount; i++)
                 {
                     WaapiLog.InternalLog($"Trying to fetch connection info ({i}/{retryCount}) ...");
-
                     if (Function.Count == 0) await GetFunctionsAsync();
                     if (Topic.Count == 0) await GetTopicsAsync();
-                    if (UICommand.Count == 0) await GetCommandsAsync();
 
+                    // This must load first so we know if we are on a console or GUI version of Wwise
                     if (ConnectionInfo == null) ConnectionInfo = await GetWwiseInfoAsync();
+                    
+                    // Console versions of WAAPI cannot use UI commands, don't even bother
+                    // loading them, this improves connection speed
+                    if (ConnectionInfo == null || !ConnectionInfo.IsCommandLine)
+                    {
+                        if (UICommand.Count == 0) await GetCommandsAsync();
+                    }
 
-                    if (ConnectionInfo != null && Function.Count != 0 && Topic.Count != 0 && UICommand.Count != 0) break;
+
+                    if (ConnectionInfo != null && Function.Count != 0 && Topic.Count != 0 && (ConnectionInfo.IsCommandLine || UICommand.Count != 0)) break;
 
                     
                     WaapiLog.InternalLog("Failed to fetch connection info! Retry in 3 seconds ...");


### PR DESCRIPTION
Hi, first of all, thanks for this. I do game modding and having automated tools for Wwise is great and your tool seems to do a lot of the heavy lifting I was expecting to have to do. So far this has worked fairly well for me.

I am using Wwise 2019.1.6.7110 and noticed that when I start a WAAPI server via `WwiseCLI.exe <project> -Waapi`, connecting to it would constantly try and fail saying that getting ui commands is not supported by this instance type. After debugging, I see it is indeed trying to get the list of UI functions, which are not available on the console version of a Waapi server.

This PR re-orders the loading of connection info to come before trying to get the UICommands. If you are on a console connection it simply skips this because they will never load.